### PR TITLE
fix: UB on Entry::as_table*

### DIFF
--- a/lib/vspace/src/page_table_entry.rs
+++ b/lib/vspace/src/page_table_entry.rs
@@ -73,12 +73,12 @@ where
 {
     pub fn as_table<const O: usize>(&self) -> Option<Table<L::NextLevel>> {
         self.is_table_entry()
-            .then_some(unsafe { Table::<L::NextLevel>::from_vaddr(self.vaddr::<O>().0 as *mut u8) })
+            .then(|| unsafe { Table::<L::NextLevel>::from_vaddr(self.vaddr::<O>().0 as *mut u8) })
     }
 
     pub fn as_table_mut<const O: usize>(&mut self) -> Option<Table<L::NextLevel>> {
         self.is_table_entry()
-            .then_some(unsafe { Table::<L::NextLevel>::from_vaddr(self.vaddr::<O>().0 as *mut u8) })
+            .then(|| unsafe { Table::<L::NextLevel>::from_vaddr(self.vaddr::<O>().0 as *mut u8) })
     }
 }
 


### PR DESCRIPTION
tldr: the code inside bool::then_some is always executed, but the code in the closure from bool::then is only executed if is true.

This is UB, because the bool::then_some is a function that takes a bool and a generic value, because of that, the value inside of it is always evaluated, independent if the bool is true/false.

it's clear if the desugarize the syntax:

```rust
// first we get the true/false for the condition
let cond: bool = self.is_table_entry();
// then we evaluate the expression to pass the value as parameter
// UB here, the is executed always, independent of the cond being true/false
let value = unsafe { Table::<L::NextLevel>::from_vaddr(self.vaddr::<O>().0 as *mut u8) };
// then we call the function `bool::then_some`.
bool::then_some(cond, value)
```

The solution is simply change it to bool::then, because the parameter it's a closure, it's lazy evaluated, and only executed if the condition is true.

As mentioned at https://github.com/rust-lang/rust/blob/5cb2e7dfc362662b0036faad3bab88d73027fd05/src/tools/clippy/clippy_lints/src/transmute/mod.rs#L468-L520

And presented at https://youtu.be/hBjQ3HqCfxs?si=nrIz6ZHnxEHO6Pik&t=53
